### PR TITLE
결과페이지에서 뒤로갔을때 위스키 이름이 사라지는 버그수정

### DIFF
--- a/frontend/components/templates/ReviewBox.tsx
+++ b/frontend/components/templates/ReviewBox.tsx
@@ -105,6 +105,7 @@ const ReviewBox = () => {
           >
             <Autocomplete
               freeSolo
+              value={whiskey.name}
               onChange={(e) => {
                 updateWhiskey("name", (e.target as HTMLInputElement).outerText);
               }}


### PR DESCRIPTION
결과페이지에서 뒤로가기 눌렀을때 위스키 이름이 사라지는 버그 수정
onChange가 추가 되었는데 value값이 없어서 생기는 문제.